### PR TITLE
Typo in pooch error message

### DIFF
--- a/bed_reader/_sample_data.py
+++ b/bed_reader/_sample_data.py
@@ -71,7 +71,7 @@ def sample_file(filepath: Union[str, Path]) -> str:
     if pooch is None:
         raise ImportError(
             "The function sample_file() requires pooch. "
-            + "Install it with 'pip install --upgrade bed-reader[sample]'."
+            + "Install it with 'pip install --upgrade bed-reader[samples]'."
         )
 
     filepath = Path(filepath)


### PR DESCRIPTION
Trying to use pip install --upgrade bed-reader[sample] throws a warning:

`WARNING: bed-reader 1.0.2 does not provide the extra 'sample'`

Needs to be pip install --upgrade bed-reader[samples] to be able to copy paste and successfully upgrade the package